### PR TITLE
Make novendor ignore vendor packages in hidden directories

### DIFF
--- a/novendor/novendor_test.go
+++ b/novendor/novendor_test.go
@@ -188,6 +188,22 @@ package bar; import _ "{{index . "vendor/github.com/org/library/subpackage_linux
 				},
 			},
 		},
+		{
+			name: "does not consider vendored libraries in hidden directories",
+			getArgs: func(projectDir string) (string, []string) {
+				return path.Join(projectDir), nil
+			},
+			files: []gofiles.GoFileSpec{
+				{
+					RelPath: "foo.go",
+					Src:     `package main`,
+				},
+				{
+					RelPath: ".hidden/vendor/github.com/org/library/bar/bar.go",
+					Src:     `package bar`,
+				},
+			},
+		},
 	} {
 		currTmpDir, err := ioutil.TempDir(tmpDir, "")
 		require.NoError(t, err, "Case %d (%s)", i, currCase.name)


### PR DESCRIPTION
Change behavior so that any candidate for a vendored package that
is within a hidden directory will not be considered as a vendored
package.

Fixes #22